### PR TITLE
hashicorp vault 구축

### DIFF
--- a/vault/Chart.yaml
+++ b/vault/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: vault
+version: 0.1.0
+description: A Helm chart for HashiCorp Vault stack
+
+dependencies:
+  - name: vault
+    version: "0.28.1"
+    repository: "https://helm.releases.hashicorp.com"

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -1,0 +1,82 @@
+vault:
+  # Vault Helm Chart Value Overrides
+  global:
+    enabled: true
+    tlsDisable: true
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 250m
+      limits:
+        memory: 256Mi
+        cpu: 250m
+
+  server:
+    # Stateful storage
+    dataStorage:
+      enabled: true
+    auditStorage:
+      enabled: true
+
+    # For HA configuration and because we need to manually init the vault,
+    # we need to define custom readiness/liveness Probe settings
+    readinessProbe:
+      enabled: true
+      path: "/v1/sys/health?standbyok=true&sealedcode=204&uninitcode=204"
+    livenessProbe:
+      enabled: true
+      path: "/v1/sys/health?standbyok=true"
+      initialDelaySeconds: 60
+
+    # This configures the Vault Statefulset to create a PVC for audit logs.
+    # See https://www.vaultproject.io/docs/audit/index.html to know more
+    auditStorage:
+      enabled: true
+    standalone:
+      enabled: false
+
+    # Run Vault in "HA" mode.
+    ha:
+      enabled: true
+      replicas: 3
+      raft:
+        enabled: true
+        setNodeId: true
+
+        config: |
+          ui = true
+          cluster_name = "vault-integrated-storage"
+          listener "tcp" {
+            address = "[::]:8200"
+            cluster_address = "[::]:8201"
+            tls_disable = "true"
+          }
+
+          storage "raft" {
+            path = "/vault/data"
+            retry_join {
+              leader_api_addr = "http://vault-0.vault-internal:8200"
+            }
+            retry_join {
+              leader_api_addr = "http://vault-1.vault-internal:8200"
+            }
+            retry_join {
+              leader_api_addr = "http://vault-2.vault-internal:8200"
+            }
+            autopilot {
+              server_stabilization_time = "10s"
+              last_contact_threshold = "10s"
+              min_quorum = 3
+              cleanup_dead_servers = false
+              dead_server_last_contact_threshold = "10m"
+              max_trailing_logs = 1000
+              disable_upgrade_migration = false
+            }
+          }
+
+  # Vault UI
+  ui:
+    enabled: true
+    serviceType: "LoadBalancer"
+    serviceNodePort: null
+    externalPort: 8200

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -1,15 +1,7 @@
 vault:
-  # Vault Helm Chart Value Overrides
   global:
     enabled: true
     tlsDisable: true
-    resources:
-      requests:
-        memory: 256Mi
-        cpu: 250m
-      limits:
-        memory: 256Mi
-        cpu: 250m
 
   server:
     # Stateful storage


### PR DESCRIPTION
- [ ] Auto unseal 적용

vault는 재시작시 seal 모드로 전환되어 접근이 불가능하게 됩니다. unseal key를 사용해 unseal 모드로 전환해야 합니다.
k8s pod 재스케줄링에 의해 Auto Unseal이 권장됩니다.

Prerequisites에 Terraform이 필요하므로, 나중에 적용할 예정입니다.

resolved #31 

Reference
- https://developer.hashicorp.com/vault/tutorials/kubernetes/kubernetes-raft-deployment-guide#vault-seal-configuration
- https://developer.hashicorp.com/vault/tutorials/auto-unseal/autounseal-gcp-kms